### PR TITLE
Api Response Update

### DIFF
--- a/CardanoSharp.Koios.Sample/Program.cs
+++ b/CardanoSharp.Koios.Sample/Program.cs
@@ -20,7 +20,7 @@ var scriptClient = RestService.For<IScriptClient>("https://api.koios.rest/api/v0
 Console.WriteLine("Query Chain Tip");
 var chainTip = networkClient.GetChainTip().Result;
 string latestEpoch = "294";
-foreach (var ct in chainTip)
+foreach (var ct in chainTip.Content)
 {
     latestEpoch = ct.Epoch.ToString();
     Console.WriteLine(JsonSerializer.Serialize(ct));
@@ -30,7 +30,7 @@ Console.WriteLine();
 // Get Genesis Info
 Console.WriteLine("Get Genesis Info");
 var genesisInfo = networkClient.GetGenesisInfo().Result;
-foreach (var gi in genesisInfo)
+foreach (var gi in genesisInfo.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(gi));
 }
@@ -39,7 +39,7 @@ Console.WriteLine();
 // Get Historical Tokenomic Stats
 Console.WriteLine("Get Historical Tokenomic Stats");
 var historicalStats = networkClient.GetHistoricalTokenomicStats(latestEpoch).Result;
-foreach (var hs in historicalStats)
+foreach (var hs in historicalStats.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(hs));
 }
@@ -48,7 +48,7 @@ Console.WriteLine();
 // Get Epoch Information
 Console.WriteLine("Get Epoch Information");
 var epochInformations = epochClient.GetEpochInformation().Result;
-foreach (var ei in epochInformations)
+foreach (var ei in epochInformations.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(ei));
 }
@@ -57,7 +57,7 @@ Console.WriteLine();
 // Get Epoch Information
 Console.WriteLine("Get Protocol Parameters");
 var protocolParameters = epochClient.GetProtocolParameters(latestEpoch).Result;
-foreach (var pp in protocolParameters)
+foreach (var pp in protocolParameters.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pp));
 }
@@ -66,7 +66,7 @@ Console.WriteLine();
 // Get Block List
 Console.WriteLine("Get Block List");
 var blockList = blockClient.GetBlockList().Result;
-foreach (var bl in blockList)
+foreach (var bl in blockList.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(bl));
 }
@@ -77,7 +77,7 @@ Console.WriteLine("Get Block Information");
 var blockHashes = new string[] {"f6192a1aaa6d3d05b4703891a6b66cd757801c61ace86cbe5ab0d66e07f601ab"};
 var getBlockInfoRequest = new GetBlockInformationRequest() {BlockHashes = blockHashes};
 var blockInfo = blockClient.GetBlockInfo(getBlockInfoRequest).Result;
-foreach (var bi in blockInfo)
+foreach (var bi in blockInfo.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(bi));
 }
@@ -87,7 +87,7 @@ Console.WriteLine();
 Console.WriteLine("Get Block Transactions");
 var blockHash = "f6192a1aaa6d3d05b4703891a6b66cd757801c61ace86cbe5ab0d66e07f601ab";
 var blockTransactions = blockClient.GetBlockTransactions(blockHash).Result;
-foreach (var bt in blockTransactions)
+foreach (var bt in blockTransactions.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(bt));
 }
@@ -106,7 +106,7 @@ var transactionRequest = new GetTransactionRequest
 // Get Transaction Information
 Console.WriteLine("Get Transaction Information");
 var transactionInformation = transactionClient.GetTransactionInformation(transactionRequest).Result;
-foreach (var ti in transactionInformation)
+foreach (var ti in transactionInformation.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(ti));
 }
@@ -115,7 +115,7 @@ Console.WriteLine();
 // Get Transaction UTxOs
 Console.WriteLine("Get Transaction UTxOs");
 var transactionUtxos = transactionClient.GetTransactionUtxos(transactionRequest).Result;
-foreach (var tu in transactionUtxos)
+foreach (var tu in transactionUtxos.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(tu));
 }
@@ -124,7 +124,7 @@ Console.WriteLine();
 // Get Transaction Metadata
 Console.WriteLine("Get Transaction Metadata");
 var transactionMetadata = transactionClient.GetTransactionMetadata(transactionRequest).Result;
-foreach (var tm in transactionMetadata)
+foreach (var tm in transactionMetadata.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(tm));
 }
@@ -159,7 +159,7 @@ Console.WriteLine();
 Console.WriteLine("Get Address Information");
 var address = "addr1qyp9kz50sh9c53hpmk3l4ewj9ur794t2hdqpngsjn3wkc5sztv9glpwt3frwrhdrltjaytc8ut2k4w6qrx3p98zad3fq07xe9g";
 var addressInformation = addressClient.GetAddressInformation(address).Result;
-foreach (var ai in addressInformation)
+foreach (var ai in addressInformation.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(ai));
 }
@@ -178,7 +178,7 @@ var addressTransactionRequest = new AddressTransactionRequest()
 // Get Address Transactions
 Console.WriteLine("Get Address Transactions");
 var addressTransactions = addressClient.GetAddressTransactions(addressTransactionRequest).Result;
-foreach (var at in addressTransactions)
+foreach (var at in addressTransactions.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(at));
 }
@@ -189,7 +189,7 @@ Console.WriteLine("Get Address Assets");
 var addressForAssets =
     "addr1q8h22z0n3zqecr9n4q9ysds2m2ms3dqesz575accjpc3jclw55yl8zypnsxt82q2fqmq4k4hpz6pnq9fafm33yr3r93sgnpdw6";
 var addressAssets = addressClient.GetAddressAssets(addressForAssets).Result;
-foreach (var aa in addressAssets)
+foreach (var aa in addressAssets.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(aa));
 }
@@ -209,7 +209,7 @@ var credentialTransactionRequest = new CredentialTransactionRequest()
 Console.WriteLine("Get Transactions from payment credentials");
 var credentialTransactions = addressClient
     .GetCredentialTransactions(credentialTransactionRequest).Result;
-foreach (var ct in credentialTransactions)
+foreach (var ct in credentialTransactions.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(ct));
 }
@@ -218,7 +218,7 @@ Console.WriteLine();
 // Get All Stake Accounts
 Console.WriteLine("Get All Stake Accounts");
 var stakeAccounts = accountClient.GetAllStakeAccounts().Result;
-foreach (var sa in stakeAccounts)
+foreach (var sa in stakeAccounts.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sa));
 }
@@ -228,7 +228,7 @@ Console.WriteLine();
 Console.WriteLine("Get Stake Information");
 var stakeAddress = "stake1u8yxtugdv63wxafy9d00nuz6hjyyp4qnggvc9a3vxh8yl0ckml2uz";
 var stakeInformation = accountClient.GetStakeInformation(stakeAddress).Result;
-foreach (var si in stakeInformation)
+foreach (var si in stakeInformation.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(si));
 }
@@ -237,7 +237,7 @@ Console.WriteLine();
 // Get Stake Rewards
 Console.WriteLine("Get Stake Rewards");
 var stakeRewards = accountClient.GetStakeRewards(stakeAddress).Result;
-foreach (var sr in stakeRewards)
+foreach (var sr in stakeRewards.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sr));
 }
@@ -246,7 +246,7 @@ Console.WriteLine();
 // Get Stake Updates
 Console.WriteLine("Get Stake Updates");
 var stakeUpdates = accountClient.GetStakeUpdates(stakeAddress).Result;
-foreach (var su in stakeUpdates)
+foreach (var su in stakeUpdates.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(su));
 }
@@ -255,7 +255,7 @@ Console.WriteLine();
 // Get Stake Addresses
 Console.WriteLine("Get Stake Addresses");
 var stakeAddresses = accountClient.GetStakeAddresses(stakeAddress).Result;
-foreach (var sa in stakeAddresses)
+foreach (var sa in stakeAddresses.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sa));
 }
@@ -264,7 +264,7 @@ Console.WriteLine();
 // Get Stake Assets
 Console.WriteLine("Get Stake Assets");
 var stakeAssets = accountClient.GetStakeAssets(stakeAddress).Result;
-foreach (var sa in stakeAssets)
+foreach (var sa in stakeAssets.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sa));
 }
@@ -273,7 +273,7 @@ Console.WriteLine();
 // Get Stake History
 Console.WriteLine("Get Stake History");
 var stakeHistory = accountClient.GetStakeHistory(stakeAddress).Result;
-foreach (var sh in stakeHistory)
+foreach (var sh in stakeHistory.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sh));
 }
@@ -284,7 +284,7 @@ Console.WriteLine("Get Asset Address List");
 var policyId = "d3501d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff";
 var assetName = "444f4e545350414d";
 var assetAddresses = assetClient.GetAddresses(policyId, assetName).Result;
-foreach (var aa in assetAddresses)
+foreach (var aa in assetAddresses.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(aa));
 }
@@ -293,7 +293,7 @@ Console.WriteLine();
 // Get Asset Information
 Console.WriteLine("Get Asset Information");
 var assetInformations = assetClient.GetInfo(policyId, assetName).Result;
-foreach (var ai in assetInformations)
+foreach (var ai in assetInformations.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(ai));
 }
@@ -302,7 +302,7 @@ Console.WriteLine();
 // Get Asset Transactions
 Console.WriteLine("Get Asset Transactions");
 var assetTransactions = assetClient.GetTransactions(policyId, assetName).Result;
-foreach (var at in assetTransactions)
+foreach (var at in assetTransactions.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(at));
 }
@@ -311,7 +311,7 @@ Console.WriteLine();
 // Get Pool List
 Console.WriteLine("Get Pool List");
 var poolList = poolClient.GetList().Result;
-foreach (var pl in poolList)
+foreach (var pl in poolList.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pl));
 }
@@ -329,7 +329,7 @@ var poolBech32Ids = new PoolInformationRequest()
     }
 };
 var poolInformations = poolClient.GetInformation(poolBech32Ids).Result;
-foreach (var pi in poolInformations)
+foreach (var pi in poolInformations.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pi));
 }
@@ -340,7 +340,7 @@ Console.WriteLine("Get Pool Delegators");
 var poolBech32 = "pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc";
 var epochNo = "294"; //optional
 var poolDelegators = poolClient.GetDelegators(poolBech32, epochNo).Result;
-foreach (var pd in poolDelegators)
+foreach (var pd in poolDelegators.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pd));
 }
@@ -349,7 +349,7 @@ Console.WriteLine();
 // Get Pool Blocks
 Console.WriteLine("Get Pool Blocks");
 var poolBlocks = poolClient.GetBlocks(poolBech32, epochNo).Result;
-foreach (var pb in poolBlocks)
+foreach (var pb in poolBlocks.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pb));
 }
@@ -358,7 +358,7 @@ Console.WriteLine();
 // Get Pool Updates
 Console.WriteLine("Get Pool Updates");
 var poolUpdates = poolClient.GetUpdates(poolBech32).Result;
-foreach (var pu in poolUpdates)
+foreach (var pu in poolUpdates.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pu));
 }
@@ -367,7 +367,7 @@ Console.WriteLine();
 // Get Pool Relays
 Console.WriteLine("Get Pool Relays");
 var poolRelays = poolClient.GetRelays().Result;
-foreach (var pr in poolRelays)
+foreach (var pr in poolRelays.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pr));
 }
@@ -376,7 +376,7 @@ Console.WriteLine();
 // Get Pool Metadata
 Console.WriteLine("Get Pool Metadata");
 var poolMetadata = poolClient.GetMetadata().Result;
-foreach (var pm in poolMetadata)
+foreach (var pm in poolMetadata.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(pm));
 }
@@ -385,7 +385,7 @@ Console.WriteLine();
 // Get Native Script List
 Console.WriteLine("Get Native Script List");
 var scriptNativeList = scriptClient.GetNativeList().Result;
-foreach (var sl in scriptNativeList)
+foreach (var sl in scriptNativeList.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sl));
 }
@@ -394,7 +394,7 @@ Console.WriteLine();
 // Get Plutus Script List
 Console.WriteLine("Get Plutus Script List");
 var scriptPlutusList = scriptClient.GetPlutusList().Result;
-foreach (var sl in scriptPlutusList)
+foreach (var sl in scriptPlutusList.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sl));
 }
@@ -404,7 +404,7 @@ Console.WriteLine();
 Console.WriteLine("Get Script Redeemers");
 var scriptHash = "d8480dc869b94b80e81ec91b0abe307279311fe0e7001a9488f61ff8";
 var scriptRedeemers = scriptClient.GetRedeemers(scriptHash).Result;
-foreach (var sr in scriptRedeemers)
+foreach (var sr in scriptRedeemers.Content)
 {
     Console.WriteLine(JsonSerializer.Serialize(sr));
 }

--- a/CardanoSharp.Koios.Sdk/CardanoSharp.Koios.Sdk.csproj
+++ b/CardanoSharp.Koios.Sdk/CardanoSharp.Koios.Sdk.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>4.2.3</Version>
+        <Version>5.0.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CardanoSharp.Koios.Sdk/Common/PreferValues.cs
+++ b/CardanoSharp.Koios.Sdk/Common/PreferValues.cs
@@ -1,0 +1,7 @@
+﻿namespace CardanoSharp.Koios.Sdk.Enums
+{
+    public static class PreferValues
+    {
+        public static string CountEstimated = "count=estimated";
+    }
+}

--- a/CardanoSharp.Koios.Sdk/IAccountClient.cs
+++ b/CardanoSharp.Koios.Sdk/IAccountClient.cs
@@ -7,25 +7,47 @@ namespace CardanoSharp.Koios.Sdk
     public interface IAccountClient
     {
         [Get("/account_list")]
-        Task<StakeAccount[]> GetAllStakeAccounts(int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeAccount[]>> GetAllStakeAccounts([AliasAs("limit")]int? limit = null, 
+        [AliasAs("offset")]int? offset = null, 
+        [Header("Prefer")] string prefer = null);
 
         [Get("/account_info")]
-        Task<StakeInformation[]> GetStakeInformation([AliasAs("_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeInformation[]>> GetStakeInformation([AliasAs("_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/account_rewards")]
-        Task<StakeReward[]> GetStakeRewards([AliasAs("_stake_address")] string address, 
-            [AliasAs("_epoch_no")]string? epochNo = null, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeReward[]>> GetStakeRewards([AliasAs("_stake_address")] string address, 
+            [AliasAs("_epoch_no")]string? epochNo = null, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/account_updates")]
-        Task<StakeUpdate[]> GetStakeUpdates([AliasAs("_stake_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeUpdate[]>> GetStakeUpdates([AliasAs("_stake_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/account_addresses")]
-        Task<StakeAddress[]> GetStakeAddresses([AliasAs("_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeAddress[]>> GetStakeAddresses([AliasAs("_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/account_assets")]
-        Task<StakeAsset[]> GetStakeAssets([AliasAs("_address")] string address, [AliasAs("asset_name")] string assetName = null, [AliasAs("asset_policy")] string assetPolicy = null, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeAsset[]>> GetStakeAssets([AliasAs("_address")] string address, 
+            [AliasAs("asset_name")] string assetName = null, 
+            [AliasAs("asset_policy")] string assetPolicy = null, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/account_history")]
-        Task<StakeHistory[]> GetStakeHistory([AliasAs("_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<StakeHistory[]>> GetStakeHistory([AliasAs("_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 }

--- a/CardanoSharp.Koios.Sdk/IAddressClient.cs
+++ b/CardanoSharp.Koios.Sdk/IAddressClient.cs
@@ -9,15 +9,27 @@ namespace CardanoSharp.Koios.Sdk
     public interface IAddressClient
     {
         [Get("/address_info")]
-        Task<AddressInformation[]> GetAddressInformation([AliasAs("_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<AddressInformation[]>> GetAddressInformation([AliasAs("_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Post("/address_txs")]
-        Task<AddressTransaction[]> GetAddressTransactions([Body] AddressTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<AddressTransaction[]>> GetAddressTransactions([Body] AddressTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         [Get("/address_assets")]
-        Task<AddressAsset[]> GetAddressAssets([AliasAs("_address")] string address, int? limit = null, int? offset = null);
+        Task<ApiResponse<AddressAsset[]>> GetAddressAssets([AliasAs("_address")] string address, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Post("/credential_txs")]
-        Task<AddressTransaction[]> GetCredentialTransactions([Body] CredentialTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<AddressTransaction[]>> GetCredentialTransactions([Body] CredentialTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 
     public class AddressTransactionRequest

--- a/CardanoSharp.Koios.Sdk/IAssetClient.cs
+++ b/CardanoSharp.Koios.Sdk/IAssetClient.cs
@@ -7,15 +7,24 @@ namespace CardanoSharp.Koios.Sdk
     public interface IAssetClient
     {
         [Get("/asset_address_list")]
-        Task<AssetAddress[]> GetAddresses([AliasAs("_asset_policy")] string policyId,
-            [AliasAs("_asset_name")] string assetName, int? limit = null, int? offset = null);
+        Task<ApiResponse<AssetAddress[]>> GetAddresses([AliasAs("_asset_policy")] string policyId,
+            [AliasAs("_asset_name")] string assetName, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Get("/asset_info")]
-        Task<AssetInformation[]> GetInfo([AliasAs("_asset_policy")] string policyId,
-            [AliasAs("_asset_name")] string assetName, int? limit = null, int? offset = null);
+        Task<ApiResponse<AssetInformation[]>> GetInfo([AliasAs("_asset_policy")] string policyId,
+            [AliasAs("_asset_name")] string assetName, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Get("/asset_txs")]
-        Task<AssetTransaction[]> GetTransactions([AliasAs("_asset_policy")] string policyId,
-            [AliasAs("_asset_name")] string assetName, int? limit = null, int? offset = null);
+        Task<ApiResponse<AssetTransaction[]>> GetTransactions([AliasAs("_asset_policy")] string policyId,
+            [AliasAs("_asset_name")] string assetName, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 }

--- a/CardanoSharp.Koios.Sdk/IBlockClient.cs
+++ b/CardanoSharp.Koios.Sdk/IBlockClient.cs
@@ -8,13 +8,21 @@ namespace CardanoSharp.Koios.Sdk
     public interface IBlockClient
     {
         [Get("/blocks")]
-        Task<Block[]> GetBlockList(int? limit = null, int? offset = null);
+        Task<ApiResponse<Block[]>> GetBlockList([AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Post("/block_info")]
-        Task<Block[]> GetBlockInfo([Body] GetBlockInformationRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<Block[]>> GetBlockInfo([Body] GetBlockInformationRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Get("/block_txs")]
-        Task<BlockTransaction[]> GetBlockTransactions([AliasAs("_block_hash")] string blockHash, int? limit = null, int? offset = null);
+        Task<ApiResponse<BlockTransaction[]>> GetBlockTransactions([AliasAs("_block_hash")] string blockHash, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }   
     
     public class GetBlockInformationRequest

--- a/CardanoSharp.Koios.Sdk/IEpochClient.cs
+++ b/CardanoSharp.Koios.Sdk/IEpochClient.cs
@@ -7,9 +7,15 @@ namespace CardanoSharp.Koios.Sdk
     public interface IEpochClient
     {
         [Get("/epoch_info")]
-        Task<EpochInformation[]> GetEpochInformation([AliasAs("_epoch_no")] string? epochNo = null, int? limit = null, int? offset = null);
+        Task<ApiResponse<EpochInformation[]>> GetEpochInformation([AliasAs("_epoch_no")] string? epochNo = null, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Get("/epoch_params")]
-        Task<ProtocolParameters[]> GetProtocolParameters([AliasAs("_epoch_no")] string? epochNo = null, int? limit = null, int? offset = null);
+        Task<ApiResponse<ProtocolParameters[]>> GetProtocolParameters([AliasAs("_epoch_no")] string? epochNo = null, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 }

--- a/CardanoSharp.Koios.Sdk/INetworkClient.cs
+++ b/CardanoSharp.Koios.Sdk/INetworkClient.cs
@@ -7,12 +7,15 @@ namespace CardanoSharp.Koios.Sdk
     public interface INetworkClient
     {
         [Get("/tip")]
-        Task<BlockSummary[]> GetChainTip();
+        Task<ApiResponse<BlockSummary[]>> GetChainTip();
 
         [Get("/genesis")]
-        Task<GenesisParameters[]> GetGenesisInfo();
+        Task<ApiResponse<GenesisParameters[]>> GetGenesisInfo();
 
         [Get("/totals")]
-        Task<TokenomicStats[]> GetHistoricalTokenomicStats([AliasAs("_epoch_no")] string epoch, int? limit = null, int? offset = null);
+        Task<ApiResponse<TokenomicStats[]>> GetHistoricalTokenomicStats([AliasAs("_epoch_no")] string epoch, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 }

--- a/CardanoSharp.Koios.Sdk/IPoolClient.cs
+++ b/CardanoSharp.Koios.Sdk/IPoolClient.cs
@@ -10,27 +10,45 @@ namespace CardanoSharp.Koios.Sdk
     public interface IPoolClient
     {
         [Get("/pool_list")]
-        Task<PoolItem[]> GetList(int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolItem[]>> GetList([AliasAs("limit")]int? limit = null, 
+        [AliasAs("offset")]int? offset = null, 
+        [Header("Prefer")] string prefer = null);
 
         [Post("/pool_info")]
-        Task<PoolInformation[]> GetInformation([Body] PoolInformationRequest poolBech32, int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolInformation[]>> GetInformation([Body] PoolInformationRequest poolBech32, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/pool_delegators")]
-        Task<PoolDelegator[]> GetDelegators([AliasAs("_pool_bech32")] string poolBech32,
-            [AliasAs("_epoch_no")] string? epochNo = null, int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolDelegator[]>> GetDelegators([AliasAs("_pool_bech32")] string poolBech32,
+            [AliasAs("_epoch_no")] string? epochNo = null, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/pool_blocks")]
-        Task<PoolBlock[]> GetBlocks([AliasAs("_pool_bech32")] string poolBech32,
-            [AliasAs("_epoch_no")] string epochNo, int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolBlock[]>> GetBlocks([AliasAs("_pool_bech32")] string poolBech32,
+            [AliasAs("_epoch_no")] string epochNo, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/pool_updates")]
-        Task<PoolUpdate[]> GetUpdates([AliasAs("_pool_bech32")] string poolBech32, int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolUpdate[]>> GetUpdates([AliasAs("_pool_bech32")] string poolBech32, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Get("/pool_relays")]
-        Task<PoolRelay[]> GetRelays(int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolRelay[]>> GetRelays([AliasAs("limit")]int? limit = null, 
+        [AliasAs("offset")]int? offset = null, 
+        [Header("Prefer")] string prefer = null);
         
         [Get("/pool_metadata")]
-        Task<PoolMetadata[]> GetMetadata(int? limit = null, int? offset = null);
+        Task<ApiResponse<PoolMetadata[]>> GetMetadata([AliasAs("limit")]int? limit = null, 
+        [AliasAs("offset")]int? offset = null, 
+        [Header("Prefer")] string prefer = null);
     }
 
     public class PoolInformationRequest

--- a/CardanoSharp.Koios.Sdk/IScriptClient.cs
+++ b/CardanoSharp.Koios.Sdk/IScriptClient.cs
@@ -7,11 +7,19 @@ namespace CardanoSharp.Koios.Sdk
     public interface IScriptClient
     {
         [Get("/native_script_list")]
-        Task<ScriptItem[]> GetNativeList(int? limit = null, int? offset = null);
+        Task<ApiResponse<ScriptItem[]>> GetNativeList([AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
+        
         [Get("/plutus_script_list")]
-        Task<ScriptItem[]> GetPlutusList(int? limit = null, int? offset = null);
+        Task<ApiResponse<ScriptItem[]>> GetPlutusList([AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
 
         [Get("/script_redeemers")]
-        Task<ScriptRedeemer[]> GetRedeemers([AliasAs("_script_hash")] string scriptHash, int? limit = null, int? offset = null);
+        Task<ApiResponse<ScriptRedeemer[]>> GetRedeemers([AliasAs("_script_hash")] string scriptHash, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
     }
 }

--- a/CardanoSharp.Koios.Sdk/ITransactionClient.cs
+++ b/CardanoSharp.Koios.Sdk/ITransactionClient.cs
@@ -10,20 +10,32 @@ namespace CardanoSharp.Koios.Sdk
     public interface ITransactionClient
     {
         [Post("/tx_info")]
-        Task<Transaction[]> GetTransactionInformation([Body] GetTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<Transaction[]>> GetTransactionInformation([Body] GetTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Post("/tx_utxos")]
-        Task<Transaction[]> GetTransactionUtxos([Body] GetTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<Transaction[]>> GetTransactionUtxos([Body] GetTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Post("/tx_metadata")]
-        Task<TransactionMetadata[]> GetTransactionMetadata([Body] GetTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<TransactionMetadata[]>> GetTransactionMetadata([Body] GetTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Post("/tx_status")]
-        Task<TransactionStatus[]> GetTransactionStatus([Body] GetTransactionRequest request, int? limit = null, int? offset = null);
+        Task<ApiResponse<TransactionStatus[]>> GetTransactionStatus([Body] GetTransactionRequest request, 
+            [AliasAs("limit")]int? limit = null, 
+            [AliasAs("offset")]int? offset = null, 
+            [Header("Prefer")] string prefer = null);
         
         [Headers("Content-Type: application/cbor")]
         [Post("/submittx")]
-        Task<string> Submit([Body] Stream request);
+        Task<ApiResponse<string>> Submit([Body] Stream request);
     }
 
     public class GetTransactionRequest


### PR DESCRIPTION
## Main Objectives
 - Gain access to Response Headers
 - Add `Prefer` Request Header 

### Gain access to Response Headers
Instead of returning just the payload, endpoints will pass through the response. Add `.Content` to your response to get the payload now. 

### Add `Prefer` Request Header 
If you include `prefer: PreferValues.CountEstimated`, your response will include the `Content-Range` Response Header. This Header's value will be something like this `0-4/20`
 - `0-4` this is the range of your items. this had `offset=0` and `limit=5` 
 - `20` this is the estimated total set of data. can assist with paging ui components