### PR TITLE
Fix types and names of contract properties after matching against actual responses

### DIFF
--- a/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
+++ b/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
-        <Version>1.0.8</Version>
+        <Version>1.0.9</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CardanoSharp.Koios.Client/Contracts/AccountAssetGroup.cs
+++ b/CardanoSharp.Koios.Client/Contracts/AccountAssetGroup.cs
@@ -11,7 +11,7 @@ namespace CardanoSharp.Koios.Client.Contracts
         public string? StakeAddress { get; set; }
         
         [DataMember]
-        [JsonPropertyName("asset_name")]
+        [JsonPropertyName("assets")]
         public AccountPolicyAssets[]? Assets { get; set; }
     }
 
@@ -31,15 +31,15 @@ namespace CardanoSharp.Koios.Client.Contracts
     public class AccountAsset
     {
         [DataMember]
-        [JsonPropertyName("asset_policy")]
-        public string? PolicyId { get; set; }
-
-        [DataMember]
         [JsonPropertyName("asset_name")]
         public string? AssetName { get; set; }
 
         [DataMember]
+        [JsonPropertyName("asset_name_ascii")]
+        public string? AssetNameAscii { get; set; }
+
+        [DataMember]
         [JsonPropertyName("balance")]
-        public ulong? Balance { get; set; }
+        public string? Balance { get; set; }
     }
 }

--- a/CardanoSharp.Koios.Client/Contracts/AddressAssetGroup.cs
+++ b/CardanoSharp.Koios.Client/Contracts/AddressAssetGroup.cs
@@ -31,19 +31,15 @@ namespace CardanoSharp.Koios.Client.Contracts
     public class AddressAsset
     {
         [DataMember]
-        [JsonPropertyName("asset_policy")]
-        public string? PolicyId { get; set; }
-
-        [DataMember]
         [JsonPropertyName("asset_name")]
         public string? AssetName { get; set; }
 
         [DataMember]
-        [JsonPropertyName("balance")]
-        public ulong? Balance { get; set; }
+        [JsonPropertyName("asset_name_ascii")]
+        public string? AssetNameAscii { get; set; }
 
         [DataMember]
-        [JsonPropertyName("fingerprint")]
-        public string? Fingerprint { get; set; }
+        [JsonPropertyName("balance")]
+        public string? Balance { get; set; }
     }
 }


### PR DESCRIPTION
## Description
To fix contract type and property name mismatches against API responses

## Where should the reviewer start?
Checking the property names and types of the contracts against the actual responses, not the documented types. 

## Motivation and context
To fix fields that were not correctly deserialised into expected properties. 

## Which issue it fixes?
https://github.com/cardano-community/cardanosharp-koios/issues/21

## How has this been tested?
Running the sample test harness project.
