### PR TITLE
updated package to include support for netstandard2.0

### DIFF
--- a/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
+++ b/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;netstandard2.1;</TargetFrameworks>
-        <Nullable>enable</Nullable>
-        <Version>1.0.9</Version>
+        <TargetFrameworks>netstandard2.1;netstandard2.0;</TargetFrameworks>
+        <Version>1.1.0</Version>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
+++ b/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.1;netstandard2.0;</TargetFrameworks>
         <Version>1.1.0</Version>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
+++ b/CardanoSharp.Koios.Client/CardanoSharp.Koios.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;netstandard2.1;</TargetFrameworks>
         <Nullable>enable</Nullable>
         <Version>1.0.9</Version>
     </PropertyGroup>


### PR DESCRIPTION
## Description
We only support newer versions of .NET. This update will allow us to support other versions of .NET.

## Motivation and context
User tried to use package but was met with an error of incapability.

## Which issue it fixes?
.net version mismatch
